### PR TITLE
Separate js components to clean up the main js file and make code more readable

### DIFF
--- a/app/assets/javascripts/delete-idea.js
+++ b/app/assets/javascripts/delete-idea.js
@@ -1,0 +1,20 @@
+$(document).ready(function() {
+  listenForDeleteIdea();
+});
+
+function listenForDeleteIdea() {
+  $('#ideas').delegate('#delete-idea', 'click', function() {
+    var $idea = $(this).closest('.idea');
+
+    $.ajax({
+      type: 'DELETE',
+      url: 'api/v1/ideas/' + $idea.attr('data-id') + '.json',
+      success: function() {
+        $idea.remove();
+      },
+      error: function() {
+        $idea.remove();
+      }
+    })
+  })
+}

--- a/app/assets/javascripts/downvote-idea.js
+++ b/app/assets/javascripts/downvote-idea.js
@@ -1,0 +1,18 @@
+$(document).ready(function() {
+  listenForDownvote();
+});
+
+function listenForDownvote() {
+  $('#ideas').on('click', '#downvote', function() {
+    var $idea = $(this).closest('.idea');
+    var ideaId = $idea.attr('data-id');
+
+    $.ajax({
+      type: 'PATCH',
+      url: '/api/v1/ideas/' + ideaId + '/downvote.json',
+      success: function(idea) {
+        $idea.find('.quality-rating').text(idea.quality);
+      }
+    });
+  });
+}

--- a/app/assets/javascripts/ideas.js
+++ b/app/assets/javascripts/ideas.js
@@ -1,7 +1,6 @@
 $(document).ready(function() {
   getIdeas();
   listenForCreateIdea();
-  listenForDeleteIdea();
   listenForEditIdea();
 });
 

--- a/app/assets/javascripts/ideas.js
+++ b/app/assets/javascripts/ideas.js
@@ -31,18 +31,25 @@ function hideEdit(idea) {
 }
 
 function createElementFromIdea(idea) {
-  return $('<div class="idea" data-id="' + idea.id + '"><h2>' + idea.title
-    + '</h2><h4>' + idea.body + '</h4>' + '<p><strong>Quality:</strong> '
-    + '<strong class="quality-rating">' + idea.quality + '</strong>' + '</p>'
-    + '<button type="submit" id="upvote" class="btn btn-success btn-sm">Upvote</button>' + ' | '
-    + '<button type="submit" id="downvote" class="btn btn-danger btn-sm">Downvote</button>' + ' -- '
-    + '<button id="edit-idea" class="btn btn-info btn-sm">Edit</button>'
-    + ' | ' + '<button id="delete-idea" class="btn btn-warning btn-sm">Delete</button>' + '<br>'
-    + '<div id="edit' + idea.id + '" class="editing">' + 'Edit This Idea<div class="edit-form form-group">'
-    + '<input type="text" class="form-control" id="edit-title" value="' + idea.title + '">'
-    + '<input type="textfield" class="form-control" id="edit-body" value="' + idea.body + '">' + '</div>'
-    + '<button type="submit" id="create-edit" class="btn btn-info btn-sm">Edit Idea</button>' + '</div>'
-    + '<br>' + '</div>'
+  return $(
+    '<div class="idea" data-id="' + idea.id + '">' +
+      '<h2>' + idea.title + '</h2>' +
+      '<h4>' + idea.body + '</h4>' +
+      '<p><strong>Quality:</strong> ' + '<strong class="quality-rating">' + idea.quality + '</strong>' + '</p>' +
+      '<button type="submit" id="upvote" class="btn btn-success btn-sm">Upvote</button>' + ' | ' +
+      '<button type="submit" id="downvote" class="btn btn-danger btn-sm">Downvote</button>' + ' -- ' +
+      '<button id="edit-idea" class="btn btn-info btn-sm">Edit</button>' + ' | ' +
+      '<button id="delete-idea" class="btn btn-warning btn-sm">Delete</button>' +
+      '<br>' +
+    '<div id="edit' + idea.id + '" class="editing">' + 'Edit This Idea' +
+      '<div class="edit-form form-group">' +
+        '<input type="text" class="form-control" id="edit-title" value="' + idea.title + '">' +
+        '<input type="textfield" class="form-control" id="edit-body" value="' + idea.body + '">' +
+      '</div>' +
+        '<button type="submit" id="create-edit" class="btn btn-info btn-sm">Edit Idea</button>' +
+      '</div>' +
+      '<br>' +
+    '</div>'
   );
 }
 

--- a/app/assets/javascripts/ideas.js
+++ b/app/assets/javascripts/ideas.js
@@ -1,13 +1,8 @@
-// feedback: multiple pages(i.e. js files) if it's over 50 lines think about splitting it.
-
 $(document).ready(function() {
   getIdeas();
   listenForCreateIdea();
   listenForDeleteIdea();
   listenForEditIdea();
-  listenForUpvote();
-  listenForDownvote();
-  listenForSearchIdeas();
 });
 
 function getIdeas() {
@@ -104,66 +99,6 @@ function listenForEditIdea() {
       }
     });
   });
-}
-
-function listenForUpvote() {
-  $('#ideas').on ('click','#upvote', function() {
-    var $idea = $(this).closest('.idea');
-    var ideaId = $idea.attr('data-id');
-
-    $.ajax({
-      type: 'PATCH',
-      url: '/api/v1/ideas/' + ideaId + '/upvote.json',
-      success: function(idea) {
-        $idea.find('.quality-rating').text(idea.quality);
-      }
-    });
-  });
-}
-
-function listenForDownvote() {
-  $('#ideas').on ('click','#downvote', function() {
-    var $idea = $(this).closest('.idea');
-    var ideaId = $idea.attr('data-id');
-
-    $.ajax({
-      type: 'PATCH',
-      url: '/api/v1/ideas/' + ideaId + '/downvote.json',
-      success: function(idea) {
-        $idea.find('.quality-rating').text(idea.quality);
-      }
-    });
-  });
-}
-
-function listenForDeleteIdea() {
-  $('#ideas').delegate('#delete-idea', 'click', function() {
-    var $idea = $(this).closest('.idea');
-
-    $.ajax({
-      type: 'DELETE',
-      url: 'api/v1/ideas/' + $idea.attr('data-id') + '.json',
-      success: function() {
-        $idea.remove();
-      },
-      error: function() {
-        $idea.remove();
-      }
-    })
-  })
-}
-
-function listenForSearchIdeas() {
-  $('#idea-search').keyup(function () {
-    var searchLetters = $('#idea-search').val().toLowerCase();
-
-    $('.idea').each(function (i, idea) {
-      var title = $(idea).find('h2').text().toLowerCase();
-      var body = $(idea).find('h4').text().toLowerCase();
-      var match = (title + body).indexOf(searchLetters) >= 0;
-      $(idea).toggle(match)
-    })
-  })
 }
 
 function clearForm() {

--- a/app/assets/javascripts/ideas.js
+++ b/app/assets/javascripts/ideas.js
@@ -1,3 +1,5 @@
+// feedback: multiple pages(i.e. js files) if it's over 50 lines think about splitting it.
+
 $(document).ready(function() {
   getIdeas();
   listenForCreateIdea();
@@ -133,7 +135,6 @@ function listenForDownvote() {
     });
   });
 }
-
 
 function listenForDeleteIdea() {
   $('#ideas').delegate('#delete-idea', 'click', function() {

--- a/app/assets/javascripts/search-ideas.js
+++ b/app/assets/javascripts/search-ideas.js
@@ -1,0 +1,16 @@
+$(document).ready(function() {
+  listenForSearchIdeas();
+});
+
+function listenForSearchIdeas() {
+  $('#idea-search').keyup(function() {
+    var searchLetters = $('#idea-search').val().toLowerCase();
+
+    $('.idea').each(function(i, idea) {
+      var title = $(idea).find('h2').text().toLowerCase();
+      var body = $(idea).find('h4').text().toLowerCase();
+      var match = (title + body).indexOf(searchLetters) >= 0;
+      $(idea).toggle(match)
+    })
+  })
+}

--- a/app/assets/javascripts/upvote-idea.js
+++ b/app/assets/javascripts/upvote-idea.js
@@ -1,0 +1,18 @@
+$(document).ready(function() {
+  listenForUpvote();
+});
+
+function listenForUpvote() {
+  $('#ideas').on('click', '#upvote', function() {
+    var $idea = $(this).closest('.idea');
+    var ideaId = $idea.attr('data-id');
+
+    $.ajax({
+      type: 'PATCH',
+      url: '/api/v1/ideas/' + ideaId + '/upvote.json',
+      success: function(idea) {
+        $idea.find('.quality-rating').text(idea.quality);
+      }
+    });
+  });
+}

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -87,6 +87,6 @@
         null
       ]
     },
-    "timestamp": 1449155139
+    "timestamp": 1449697915
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -14,7 +14,7 @@
       <img src="./assets/0.10.0/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" style="display:none;">
-      <div class="timestamp">Generated <abbr class="timeago" title="2015-12-03T08:05:39-07:00">2015-12-03T08:05:39-07:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2015-12-09T14:51:55-07:00">2015-12-09T14:51:55-07:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">


### PR DESCRIPTION
@rrgayhart

What's this PR do?
The idea.js file was handling everything on the javascript side, so it was cluttered and difficult to follow. I broke out all of the functions that weren't tied to the hideEdit or render helper functions. This reduced it's size by almost 100% . I also reformatted the createElement function to mirror an actual DOM model. It is now more easily changed and understood at a glance.

Where should the reviewer start?
app/assets/javascripts/ideas.js contains the main file, where getIdeas and listenfors for create and edit idea are called by document ready. From there you can see the files I broke out, which are delete-idea.js, downvote-idea.js, upvote-idea.js, and search-ideas.js. 
Also, note the createElementFromIdea function which now looks more like the DOM structure you would see in a view file.

What GIF best describes how this pull request makes you feel?
http://giphy.com/gifs/college-30-rock-tina-fey-qZLxOmmDR8Zuo
